### PR TITLE
fix issue #1 code markup color in markdown

### DIFF
--- a/theme-arc-green-updated.css
+++ b/theme-arc-green-updated.css
@@ -208,7 +208,7 @@
   --color-card: #1e252e;
   --color-markup-table-row: #ffffff06;
   --color-markup-code-block: #ffffff16;
-  --color-markup-code-inline: #e7eee0;
+  --color-markup-code-inline: #2e443;
   --color-button: #1e252e;
   --color-code-bg: #222733;
   --color-shadow: #00000058;


### PR DESCRIPTION
fixes wrong code markup highlight:
![1720613567386](https://github.com/lsd-techno/gitea-theme/assets/6795932/9df1372f-42ea-4cb7-bf08-b5176be4c4e2)
