### PR TITLE
add `.css` to automatic light/dark theme pickup

### DIFF
--- a/theme-gitea-auto.css
+++ b/theme-gitea-auto.css
@@ -1,0 +1,2 @@
+@import "./theme-gitea-light.css" (prefers-color-scheme: light);
+@import "./theme-arc-green-updated.css" (prefers-color-scheme: dark);


### PR DESCRIPTION
- add `theme-gitea-auto.css` to let gitea pickup dark-green theme by default.